### PR TITLE
feat: arregle visualización de header y footer en rutas a través de L…

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,8 @@ const Header = () => {
           alt={'remote image pc?'}
           width={50}
           height={50}
+          className="cursor-pointer"
+          onClick={() => router.push('/')}
         />
         <div className="flex flex-row items-center text-white text-sm">
           <button

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,15 +4,16 @@ import Header from './Header';
 
 interface LayoutProps {
   children: ReactNode;
-  noHeaderFooter?: boolean;
+  noHeader?: boolean;
+  noFooter?: boolean;
 }
 
-export default function Layout({ children, noHeaderFooter }: LayoutProps) {
+export default function Layout({ children, noHeader, noFooter }: LayoutProps) {
   return (
     <>
-      {!noHeaderFooter && <Header />}
+      {!noHeader && <Header />}
       <main>{children}</main>
-      {!noHeaderFooter && <Footer />}
+      {!noFooter && <Footer />}
     </>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,17 +4,15 @@ import type { AppProps } from 'next/app';
 import type { ReactElement, ReactNode } from 'react';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement) => ReactNode
-}
+  getLayout?: (_page: ReactElement) => ReactNode;
+};
 
 type AppPropsWithLayout = AppProps & {
-  Component: NextPageWithLayout
-}
-
+  Component: NextPageWithLayout;
+};
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
 
-  const getLayout = Component.getLayout ?? ((page) => page)
-
-  return getLayout(<Component {...pageProps} />)
+  return getLayout(<Component {...pageProps} />);
 }

--- a/pages/artists.tsx
+++ b/pages/artists.tsx
@@ -1,18 +1,18 @@
-import CategoriesBar from "@/components/CategoriesBar";
-import MiniHero from "@/components/MiniHero";
-import SearchNavBar from "@/components/SearchNavbar";
-import Slider from "@/components/Slider";
-
+import CategoriesBar from '@/components/CategoriesBar';
+import Layout from '@/components/Layout';
+import MiniHero from '@/components/MiniHero';
+import SearchNavBar from '@/components/SearchNavbar';
+import Slider from '@/components/Slider';
 
 export default function artists() {
   return (
-    <>
-      <MiniHero/>
-      <SearchNavBar/>
-      <Slider/>
-      <Slider/>
-      <CategoriesBar/>
-      <Slider/>
-    </>
+    <Layout>
+      <MiniHero />
+      <SearchNavBar />
+      <Slider />
+      <Slider />
+      <CategoriesBar />
+      <Slider />
+    </Layout>
   );
 }

--- a/pages/brands.tsx
+++ b/pages/brands.tsx
@@ -1,18 +1,18 @@
-import CategoriesBar from "@/components/CategoriesBar";
-import MiniHero from "@/components/MiniHero";
-import SearchNavBar from "@/components/SearchNavbar";
-import Slider from "@/components/Slider";
-
+import CategoriesBar from '@/components/CategoriesBar';
+import Layout from '@/components/Layout';
+import MiniHero from '@/components/MiniHero';
+import SearchNavBar from '@/components/SearchNavbar';
+import Slider from '@/components/Slider';
 
 export default function brands() {
   return (
-    <>
-      <MiniHero/>
-      <SearchNavBar/>
-      <Slider/>
-      <Slider/>
-      <CategoriesBar/>
-      <Slider/>
-    </>
+    <Layout>
+      <MiniHero />
+      <SearchNavBar />
+      <Slider />
+      <Slider />
+      <CategoriesBar />
+      <Slider />
+    </Layout>
   );
 }

--- a/pages/details.tsx
+++ b/pages/details.tsx
@@ -1,16 +1,16 @@
 import ArtistInfo from '@/components/ArtistInfo';
 import CategoriesBar from '@/components/CategoriesBar';
+import Layout from '@/components/Layout';
 import SearchNavBar from '@/components/SearchNavbar';
 import Slider from '@/components/Slider';
 
-
 export default function details() {
   return (
-    <>
-      <SearchNavBar/>
-      <ArtistInfo/>
-      <CategoriesBar/>
+    <Layout>
+      <SearchNavBar />
+      <ArtistInfo />
+      <CategoriesBar />
       <Slider />
-    </>
+    </Layout>
   );
 }

--- a/pages/post.tsx
+++ b/pages/post.tsx
@@ -6,7 +6,7 @@ import sloganPc from '../public/slogan-pc.svg';
 
 export default function post() {
   return (
-    <Layout noHeaderFooter>
+    <Layout noHeader noFooter>
       <div className="flex flex-col sm:flex-row h-screen">
         <aside
           style={{ backgroundColor: '#1B4DB1' }}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,14 +1,13 @@
 import ButtonAction from '@/components/atoms/ButtonAction';
 import ButtonSection from '@/components/atoms/ButtonSection';
 import Card from '@/components/Card';
+import Layout from '@/components/Layout';
 import Image from 'next/image';
-
+import footerImage from '../public/assets/footer-image.jpg';
 
 export default function profile() {
-
-
   return (
-    <>
+    <Layout noFooter>
       <div className="bg-BLUE w-full h-129 relative flex justify-center">
         <Image
           className="w-117 h-117 absolute top-16"
@@ -20,27 +19,31 @@ export default function profile() {
       </div>
 
       <div className="h-44 mt-11 m-auto flex justify-around p-5 sm:w-96">
-        <ButtonSection name='Mis votos'/>
-        <ButtonSection name='Mis publicaciones'/>
+        <ButtonSection name="Mis votos" />
+        <ButtonSection name="Mis publicaciones" />
       </div>
 
-      
       <div className="m-auto grid max-sm:grid-cols-1 sm:grid-cols-2 sm:grid-row-2 lg:grid-cols-3 lg:grid-row-3 lg:w-10/12 md:w-8/12">
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
-        <Card fill="#FF64BC"/>
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
+        <Card fill="#FF64BC" />
       </div>
       <div className="h-40 w-full flex items-center justify-center lg:hidden">
-        <ButtonAction name='Ver más'/>
+        <ButtonAction name="Ver más" />
       </div>
       <div className="h-40 w-full flex items-center justify-center max-lg:hidden">
         1 2 3 Pagination 4 5 6
       </div>
-    </>
+      <Image
+        src={footerImage}
+        alt="image-footer"
+        className="w-full object-cover h-[200px]"
+      />
+    </Layout>
   );
 }

--- a/pages/profile2.tsx
+++ b/pages/profile2.tsx
@@ -1,9 +1,12 @@
 import ButtonAction from '@/components/atoms/ButtonAction';
+import Layout from '@/components/Layout';
 import ButtonAdd from '@/components/svgs/ButtonAdd';
+import Image from 'next/image';
+import footerImage from '../public/assets/footer-image.jpg';
 
 export default function profile2() {
   return (
-    <>
+    <Layout noFooter>
       <div className="bg-BLUE w-full h-129 relative flex justify-center">
         <h1 className="text-white w-full mt-auto mb-auto ml-20 font-bold text-4xl">
           Perfil
@@ -16,7 +19,7 @@ export default function profile2() {
             <ButtonAdd
               svgProps={{ className: 'w-220 h-206 rounded-2xl bg-GRAY2' }}
             />
-            <p className='max-md:text-center'>Agrega una foto de perfil</p>
+            <p className="max-md:text-center">Agrega una foto de perfil</p>
           </div>
 
           <div className="w-640 m-auto max-lg:w-96 max-md:w-full">
@@ -53,17 +56,20 @@ export default function profile2() {
           <div className="flex justify-between max-sm:flex-col max-md:items-center">
             <ButtonAdd
               svgProps={{
-                className: 'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
+                className:
+                  'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
               }}
             />
             <ButtonAdd
               svgProps={{
-                className: 'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
+                className:
+                  'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
               }}
             />
             <ButtonAdd
               svgProps={{
-                className: 'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
+                className:
+                  'w-300 h-152 bg-GRAY2 rounded-2xl max-lg:w-52 max-md:mb-10 max-md:w-full',
               }}
             />
           </div>
@@ -72,6 +78,11 @@ export default function profile2() {
           <ButtonAction name="Guardar cambios" />
         </div>
       </div>
-    </>
+      <Image
+        src={footerImage}
+        alt="image-footer"
+        className="w-full object-cover h-[200px]"
+      />
+    </Layout>
   );
 }

--- a/pages/tournaments.tsx
+++ b/pages/tournaments.tsx
@@ -1,18 +1,18 @@
-import CategoriesBar from "@/components/CategoriesBar";
-import MiniHero from "@/components/MiniHero";
-import SearchNavBar from "@/components/SearchNavbar";
-import Slider from "@/components/Slider";
-
+import CategoriesBar from '@/components/CategoriesBar';
+import Layout from '@/components/Layout';
+import MiniHero from '@/components/MiniHero';
+import SearchNavBar from '@/components/SearchNavbar';
+import Slider from '@/components/Slider';
 
 export default function tournaments() {
   return (
-    <>
-      <MiniHero/>
-      <SearchNavBar/>
-      <Slider/>
-      <Slider/>
-      <CategoriesBar/>
-      <Slider/>
-    </>
+    <Layout>
+      <MiniHero />
+      <SearchNavBar />
+      <Slider />
+      <Slider />
+      <CategoriesBar />
+      <Slider />
+    </Layout>
   );
 }


### PR DESCRIPTION
En componente Header: Agregué una navegación a la ruta raiz cuando se apreta el botón PC? que están el header.
En componente Layout: Separé las props del componente Layout para que pueda elegir cuando no quiero que se renderize o el Header o el Footer, antes se renderizaban juntos si o si.
en _app: simplemente le puse un _page, porque lanzaba en cada nuevo commit una advertencia de que ese argumento no se utilizaba, con el guión bajo aclaro que es intencional y dejó de aparecer el warning.
Las rutas: artists, brands, details, tournaments y profiles fueron envueltas en <Layout> de manera que cada una renderize el header y el footer.
Para las rutas profile y profile 2 lo que hice fue envolverlo en el componenete Layout pero le agregué la prop de noFooter (porque en ese caso era una imagen de menor altura y no tenía que tener el input de búsqueda, por lo que la mejor manera de solucionarlo que encontré fue que se renderize solo el Header. Y para que siga estando la imagen en el pie la agregue como Image de la carpeta Public definiendo manualmente el tamaño que quisera que tenga.
